### PR TITLE
requires Polyhedra 0.2.1

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 BinDeps
-Polyhedra 0.2 0.3
+Polyhedra 0.2.1 0.3
 @osx Homebrew


### PR DESCRIPTION
since convexhull was not defined in 0.2.0