### PR TITLE
 Add (low level) interface to `lrs_solve_lp`

### DIFF
--- a/src/LRSLib.jl
+++ b/src/LRSLib.jl
@@ -2,6 +2,7 @@ module LRSLib
 
 using BinDeps
 using Polyhedra
+using Markdown
 
 if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
     include("../deps/deps.jl")
@@ -33,5 +34,6 @@ include("matrix.jl")
 include("conversion.jl")
 include("redund.jl")
 include("polyhedron.jl")
+include("lp.jl")
 
 end # module

--- a/src/lp.jl
+++ b/src/lp.jl
@@ -1,0 +1,173 @@
+#=
+Interface to lrs_solve_lp
+
+=#
+
+
+mutable struct LRSLinprogSolution
+    status::Symbol  # :Optimal, :Infeasible, :Unbounded, :UserLimit, or :Error
+    objval::Union{Nothing,Rational{BigInt}}
+    sol::Vector{Rational{BigInt}}
+    attrs::Dict
+end
+
+
+function setobj(P::Ptr{Clrs_dic}, Q::Ptr{Clrs_dat},
+                c::Vector{<:Union{Rational,Integer}}, maximize::Bool)
+    field = maximize ? :maximize : :minimize
+    row = Vector{Rational{BigInt}}(undef, unsafe_load(P).d+1)
+    row[1] = zero(eltype(row))
+    row[2:end] = maximize ? c : -c
+    unsafe_field_store!(Q, field, Clrs_true)
+    setrow(P, Q, 0, row, true)
+end
+
+setobj(m::HMatrix, c::Vector{<:Real}, maximize::Bool) =
+    setobj(m.P, m.Q, c, maximize)
+
+@doc """
+    setobj(m::HMatrix, c::Vector{<:Real}, maximize::Boo)
+
+Set the objective function vector `c` for `m`. Set `maximize` to true (false,
+resp.) if the objective is to be maximized (minimized, resp.).
+""" setobj
+
+
+# ccall to `lrs_solve_lp` with init and close
+function lrs_solve_lp(P::Ptr{Clrs_dic}, Q::Ptr{Clrs_dat})
+    @lrs_ccall init Clong (Ptr{Cchar},) C_NULL
+    found = (
+        Clrs_true ==
+        @lrs_ccall solve_lp Clong (Ptr{Clrs_dic}, Ptr{Clrs_dat}) P Q
+    )
+    @lrs_ccall close Cvoid (Ptr{Cchar},) "lp:"
+    found
+end
+
+objnum(m::HMatrix) = extractbigint(unsafe_load(m.P).objnum)
+objden(m::HMatrix) = extractbigint(unsafe_load(m.P).objden)
+
+@doc doc"""
+    lpsolve(m::HMatrix)
+
+Solve the linear program given by `m`. Return an instance of the type:
+
+    mutable struct LRSLinprogSolution
+        status::Symbol
+        objval::Rational{BigInt}
+        sol::Vector{Rational{BigInt}}
+        attrs::Dict
+    end
+
+# Examples
+
+Suppose we want to solve the problem,
+``\max x_1`` subject to ``4 x_1 + 2 x_2 \leq 3, x_1 \geq 0, x_2 \geq 0``:
+
+```julia-repl
+julia> c = [1, 0];
+julia> A = [4 2; -1 0; 0 -1];
+julia> b = [3, 0, 0];
+julia> maximize = true;
+julia> hr = hrep(A, b);
+julia> m = RepMatrix(hr);
+julia> setobj(m, c, maximize)  # Set the objective;
+julia> sol = lpsolve(m)  # Solve the problem;
+```
+
+Status:
+
+```julia-repl
+julia> sol.status
+:Optimal
+```
+
+Optimal value:
+
+```julia-repl
+julia> sol.objval
+3//4
+```
+
+Optimal solution:
+
+```julia-repl
+julia> sol.status
+:Optimal
+```
+"""
+function lpsolve(m::HMatrix)
+    found = lrs_solve_lp(m.P, m.Q)
+    unbounded = Bool(unsafe_load(m.Q).unbounded)
+    attr = Dict()
+
+    if unbounded || !found
+        status = unbounded ? :Unbounded : :Infeasible
+        return LRSLinprogSolution(status, nothing, Rational{BigInt}[], attr)
+    end
+
+    # found
+    status = :Optimal
+    objval = objnum(m) // objden(m)
+    sol = Vector{Rational{BigInt}}(undef, unsafe_load(m.P).d_orig)
+    out = getsolution(m, 0)
+    copyto!(sol, out[2:end])
+    return LRSLinprogSolution(status, objval, sol, attr)
+end
+
+
+# lrs_lpoutput from lrslib.c
+# For debugging
+function print_lpoutput(m::HMatrix, print_solution::Bool=false)
+    P, Q = unsafe_load(m.P), unsafe_load(m.Q)
+    output = @lrs_ccall alloc_mp_vector Clrs_mp_vector (Clong,) Q.n
+
+    for col in 0:(Q.n)-1
+        found = (
+            Clrs_true ==
+            @lrs_ccall getsolution Clong (Ptr{Clrs_dic}, Ptr{Clrs_dat}, Clrs_mp_vector, Clong) m.P m.Q output col
+        )
+        if print_solution
+            if found
+                println("col=$(col): found")
+                @lrs_ccall printoutput Cvoid (Ptr{Clrs_dat}, Clrs_mp_vector) m.Q output
+                println()
+            else
+                println("col=$(col): not found")
+            end
+        end
+    end
+
+    num = extractbigint(P.objnum)
+    den = extractbigint(P.objden)
+    println("*Objective function has value $(num)/$(den)")
+
+    print("*Primal:")
+    for i in 1:Q.n-1
+        print(" x_$i=")
+        num = extractbigint(unsafe_load(output, i+1))
+        den = extractbigint(unsafe_load(output, 1))
+        print(num, "/", den)
+    end
+    println()
+
+    @lrs_ccall clear_mp_vector Nothing (Clrs_mp_vector, Clong) output Q.n
+
+    if Q.nlinearity > 0
+        println("*Linearities in input file - partial dual solution only")
+    end
+
+    print("*Dual:")
+    for i in 0:P.d-1
+        C_i = unsafe_load(P.C, i+1)
+        Col_i = unsafe_load(P.Col, i+1)
+        idx = unsafe_load(Q.inequality, C_i-Q.lastdv+1)
+        print(" y_$(idx)=")
+        temp1 = extractbigint(unsafe_load(Q.Lcm, Col_i+1)) * (-1)
+        temp1 *= extractbigint(unsafe_load(unsafe_load(P.A, 1), Col_i+1))
+        temp2 = extractbigint(unsafe_load(Q.Gcd, Col_i+1))
+        temp2 *= extractbigint(P.det)
+        print(temp1, "/", temp2)
+    end
+    println()
+end

--- a/src/lrstypes.jl
+++ b/src/lrstypes.jl
@@ -20,6 +20,12 @@ function extractbigintat(array::Clrs_mp_vector, i::Int)
     tmp
 end
 
+function extractbigint(a::Clrs_mp)
+    tmp = BigInt()
+    ccall((:__gmpz_set, :libgmp), Cvoid, (Ptr{BigInt}, Ref{Clrs_mp}), pointer_from_objref(tmp), a)
+    tmp
+end
+
 mutable struct Clrs_dic  # dynamic dictionary data
     A::Clrs_mp_matrix
     m::Clong           # A has m+1 rows, row 0 is cost row
@@ -155,3 +161,14 @@ mutable struct Clrs_dat      # global problem data
     Qhead::Ptr{Clrs_dic}
     Qtail::Ptr{Clrs_dic}
 end
+
+
+# Utility function
+
+function unsafe_field_store!(p::Ptr{T}, name::Symbol, x, err::Bool=true) where T
+    i = Base.fieldindex(T, name, err)
+    offset = fieldoffset(T, i)
+    unsafe_store!(convert(Ptr{UInt}, p + offset), x)
+    return p
+end
+

--- a/test/lp.jl
+++ b/test/lp.jl
@@ -1,0 +1,90 @@
+using LRSLib: RepMatrix, setobj, lpsolve
+using LinearAlgebra
+
+
+@testset "Tests for lp.jl" begin
+
+    @testset "Simple test" begin
+        a = [7//3, 1//3]
+        b = 1//2
+        c = [-1//1, 0]
+        hr = hrep([HalfSpace(a, b),
+                   HalfSpace([-1//1, 0], 0),
+                   HalfSpace([0, -1//1], 0)])
+        maximize = false
+
+        status = :Optimal
+        val = -3//14
+        x = [3//14, 0//1]
+
+        m = RepMatrix(hr)
+        setobj(m, c, maximize)
+        sol = lpsolve(m)
+
+        @test sol.objval == val
+        @test sol.sol == x
+    end
+
+    @testset "Tests from scipy/optimize/tests/test_linprog.py" begin
+
+        @testset "test_linprog_unbounded" begin
+            c = [1, 1]
+            A = [-1 1; -1 -1; -1 0; 0 -1]
+            b = [-1, 2, 0, 0]
+            maximize = true
+
+            status = :Unbounded
+
+            hr = hrep(A, b)
+            m = RepMatrix(hr)
+            setobj(m, c, maximize)
+            sol = lpsolve(m)
+
+            @test sol.status == status
+        end
+
+        @testset "test_linprog_infeasible" begin
+            c = [1, 1]
+            A = [1 0; 0 1; -1 -1]
+            b = [2, 2, -5]
+            maximize = true
+
+            status = :Infeasible
+
+            hr = hrep(A, b)
+            m = RepMatrix(hr)
+            setobj(m, c, maximize)
+            sol = lpsolve(m)
+
+            @test sol.status == status
+        end
+
+        @testset "test_nontrivial_problem" begin
+            c = [-1, 8, 4, -6]
+            A_ub = [-7 -7 6 9;
+                    1 -1 -3 0;
+                    10 -10 -7 7;
+                    6 -1 3 4]
+            b_ub = [-3, 6, -6, 6]
+            A_eq = [-10, 1, 1, -8]
+            b_eq = -4
+            n = length(c)
+            nonneg = hrep(-Matrix{Int}(I, (n, n)), zeros(Int, n))
+            maximize = false
+
+            status = :Optimal
+            desired_fun = 7083//1391
+            desired_x = [101//1391, 1462//1391, 0, 752//1391]
+
+            hr = intersect(hrep(A_ub, b_ub), HyperPlane(A_eq, b_eq), nonneg)
+            m = RepMatrix(hr)
+            setobj(m, c, maximize)
+            sol = lpsolve(m)
+
+            @test sol.status == status
+            @test sol.objval == desired_fun
+            @test sol.sol == desired_x
+        end
+
+    end  # Tests from scipy/optimize/tests/test_linprog.py
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,4 @@ include("cube.jl")
 include("simplex.jl")
 
 include("polyhedron.jl")
+include("lp.jl")


### PR DESCRIPTION
To solve

min -x s.t. 7x + y <= 3/2, x, y >= 0:

```jl
using Polyhedra
using LRSLib: RepMatrix, setobj, lpsolve

a = [7, 1]
b = 3//2
c = [-1//1, 0]
hr = hrep([HalfSpace(a, b), HalfSpace([-1//1, 0], 0), HalfSpace([0, -1//1], 0)])
maximize = false

m = RepMatrix(hr)
setobj(m, c, maximize)
sol = lpsolve(m)

println("Optimal objective value is: $(sol.objval)")
println("Optimal solution vector is: [$(sol.sol[1]), $(sol.sol[2])]")
```

```
Optimal objective value is: -3//14
Optimal solution vector is: [3//14, 0//1]
```

I am not knowledgable enough to implement interface through `MathProgBase`. I hope someone (most probably @blegat) could do in the future.