### PR TITLE
Relax compat to allow for lrslib_jll m1 version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ lrslib_jll = "3873f7d0-7b7c-52c3-bdf4-8ab39b8f337a"
 [compat]
 Polyhedra = "0.6.14"
 julia = "1.6"
-lrslib_jll = "= 0.3.3"
+lrslib_jll = "0.3.3"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ lrslib_jll = "3873f7d0-7b7c-52c3-bdf4-8ab39b8f337a"
 [compat]
 Polyhedra = "0.6.14"
 julia = "1.6"
-lrslib_jll = "0.3.3"
+lrslib_jll = "0.3.1"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ lrslib_jll = "3873f7d0-7b7c-52c3-bdf4-8ab39b8f337a"
 [compat]
 Polyhedra = "0.6.14"
 julia = "1.3"
-lrslib_jll = "= 0.3.1"
+lrslib_jll = "= 0.3"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ lrslib_jll = "3873f7d0-7b7c-52c3-bdf4-8ab39b8f337a"
 
 [compat]
 Polyhedra = "0.6.14"
-julia = "1.3"
-lrslib_jll = "= 0.3"
+julia = "1.6"
+lrslib_jll = "= 0.3.3"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ lrslib_jll = "3873f7d0-7b7c-52c3-bdf4-8ab39b8f337a"
 [compat]
 Polyhedra = "0.6.14"
 julia = "1.6"
-lrslib_jll = "0.3.1"
+lrslib_jll = "= 0.3.3"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
lrslib_jll v0.3.3 and later support apple silicon, currently the compat settings prevent use of 0.3.3 with this package.